### PR TITLE
Add Stockfish.js evaluation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,12 +5,14 @@ import EvaluationBar from './components/EvaluationBar';
 import MovesList from './components/MovesList';
 import PGNUploader from './components/PGNUploader';
 import GameInfo from './components/GameInfo';
+import useStockfish from './engine/useStockfish';
 
 function App() {
   const [pgn, setPgn] = useState('');
   const [moves, setMoves] = useState([]);
   const [currentMoveIndex, setCurrentMoveIndex] = useState(0);
   const [evaluation, setEvaluation] = useState(0);
+  const { analyze } = useStockfish();
 
   const handlePGNLoad = (loadedPgn) => {
     setPgn(loadedPgn);
@@ -34,15 +36,30 @@ function App() {
   const handleMovePlayed = (updatedMoves) => {
     setMoves(updatedMoves);
     setCurrentMoveIndex(updatedMoves.length);
+
+    const { Chess } = require('chess.js');
+    const game = new Chess();
+    updatedMoves.forEach((m) => game.move(m));
+    analyze(game.fen()).then((evalScore) => {
+      if (typeof evalScore === 'number') {
+        setEvaluation(evalScore);
+      }
+    });
   };
 
   const handleMoveClick = (index) => {
     setCurrentMoveIndex(index);
-    
-    // Generate a random evaluation for demo purposes
-    // In a real app, this would come from an engine or stored analysis
-    const randomEval = (Math.random() * 2 - 1).toFixed(1);
-    setEvaluation(parseFloat(randomEval));
+
+    const { Chess } = require('chess.js');
+    const game = new Chess();
+    for (let i = 0; i < index; i += 1) {
+      game.move(moves[i]);
+    }
+    analyze(game.fen()).then((evalScore) => {
+      if (typeof evalScore === 'number') {
+        setEvaluation(evalScore);
+      }
+    });
   };
 
   return (

--- a/src/engine/useStockfish.js
+++ b/src/engine/useStockfish.js
@@ -6,11 +6,17 @@ export default function useStockfish() {
   const engineRef = useRef(null);
 
   useEffect(() => {
-    const worker = new Worker(STOCKFISH_URL);
+    const blobUrl = URL.createObjectURL(
+      new Blob([
+        `importScripts('${STOCKFISH_URL}');`,
+      ], { type: 'application/javascript' }),
+    );
+    const worker = new Worker(blobUrl);
     worker.postMessage('uci');
     engineRef.current = worker;
     return () => {
       worker.terminate();
+      URL.revokeObjectURL(blobUrl);
     };
   }, []);
 

--- a/src/engine/useStockfish.js
+++ b/src/engine/useStockfish.js
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+const STOCKFISH_URL = 'https://cdn.jsdelivr.net/npm/stockfish/stockfish.js';
+
+export default function useStockfish() {
+  const engineRef = useRef(null);
+
+  useEffect(() => {
+    const worker = new Worker(STOCKFISH_URL);
+    worker.postMessage('uci');
+    engineRef.current = worker;
+    return () => {
+      worker.terminate();
+    };
+  }, []);
+
+  const analyze = (fen, depth = 12) => new Promise((resolve) => {
+    const worker = engineRef.current;
+    if (!worker) {
+      resolve(0);
+      return;
+    }
+
+    const handleMessage = (event) => {
+      const text = event.data;
+      if (typeof text === 'string') {
+        if (text.startsWith('info') && text.includes('score cp')) {
+          const match = text.match(/score cp (-?\d+)/);
+          if (match) {
+            const cp = parseInt(match[1], 10);
+            worker.removeEventListener('message', handleMessage);
+            worker.postMessage('stop');
+            resolve(cp / 100);
+          }
+        }
+      }
+    };
+
+    worker.addEventListener('message', handleMessage);
+    worker.postMessage(`position fen ${fen}`);
+    worker.postMessage(`go depth ${depth}`);
+  });
+
+  return { analyze };
+}


### PR DESCRIPTION
## Summary
- integrate Stockfish.js via WebAssembly worker
- compute evaluations for board positions using Stockfish

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685336f1df70832ca4b25a5fec07920c